### PR TITLE
fix(randompic): v3 兼容 - get_api() 端点加 raw 标记绕过 envelope 自动包装

### DIFF
--- a/plugins.v2/randompic/__init__.py
+++ b/plugins.v2/randompic/__init__.py
@@ -307,7 +307,7 @@ class RandomPic(_PluginBase):
 
     def get_api(self) -> List[Dict[str, Any]]:
         """注册插件API"""
-        return [
+        apis = [
             {
                 "path": "/config",
                 "endpoint": self._get_config,
@@ -330,6 +330,12 @@ class RandomPic(_PluginBase):
                 "summary": "获取状态"
             }
         ]
+        # v3 兼容：保持插件自定义响应格式（纯 dict），
+        # 绕过宿主 ResponseAPIRoute 的统一 envelope 自动包装
+        for _api in apis:
+            if isinstance(_api, dict) and "openapi_extra" not in _api:
+                _api["openapi_extra"] = {"x-moviepilot-raw-response": True}
+        return apis
 
     def _get_config(self) -> Dict[str, Any]:
         """API处理函数：返回插件配置"""


### PR DESCRIPTION
关联 Issue：Closes #21

## 背景
RandomPic v2.1 运行在 MoviePilot v3.0.0 时，插件页面显示「服务未启动或端口未配置」，但实际服务运行正常（日志持续输出「随机图库服务启动成功」）。

## 根因
MoviePilot v3 的 `ResponseAPIRoute` 会把插件 API 端点（无 response_model）的返回值自动包装成 `{success, message, data}` envelope；而插件的 Vue 联邦前端组件（Page/Dashboard）仍按 v2 时代旧格式从响应顶层直接读字段（`Object.assign(status, statusData)`、`data.server_status || 'stopped'`），字段全部落在 `data` 里读不到 → 误判服务未启动。

## 改动
`get_api()` 的 3 个端点（`/config` GET、`/config` POST、`/status` GET）统一添加 `openapi_extra: {"x-moviepilot-raw-response": true}`，绕过宿主自动包装，保持插件自定义响应格式（纯 dict），前端无需改动即可正常读取状态。

- 改动仅限 `plugins.v2/randompic/__init__.py` 的 `get_api()`（约 +8 行）
- 已在 MoviePilot v3.0.0 本地验证：reload 后页面正常显示「运行中」，图片服务正常

## 备注
另一问题（发布/安装流程丢失 `dist/assets` 前端产物导致组件加载失败）见 Issue #21 描述，需要作者检查发布包，本 PR 不涉及。